### PR TITLE
Implement basic gamification

### DIFF
--- a/src/Config.json
+++ b/src/Config.json
@@ -5,5 +5,7 @@
     "TEMPO_PARAM":"tempo",
     "HISTORICO":"historico",
     "QUESTOES":"questoes",
-    "TIPO": "tipo"
+    "TIPO": "tipo",
+    "PONTUACAO": "pontuacao",
+    "RECORDE": "recorde"
 }

--- a/src/pages/Final/Final.js
+++ b/src/pages/Final/Final.js
@@ -25,6 +25,7 @@ function Final(){
                     Você é um mestre da tabuada! 🧠💪<br/><br/>
                     ✅Você acertou {localStorage.getItem(configData.QUANTIDADE_ACERTOS)} de {localStorage.getItem(configData.QUANTIDADE_PARAM)} em tempo recorde! ⏱️⚡️<br/>
                     Você levou apenas {localStorage.getItem(configData.TEMPO_PARAM)} segundos! ⏱️<br/><br/>
+                    Pontuação final: {localStorage.getItem(configData.PONTUACAO)} | Recorde: {localStorage.getItem(configData.RECORDE)}<br/><br/>
                     Compartilhe sua conquista com seus amigos e desafie-os a superar seu desempenho!<br/><br/>
 
                     🔥 Quão rápido você pode ser? Descubra em Tabuada Divertida! 💥
@@ -34,6 +35,7 @@ function Final(){
                     Não foi dessa vez, você ficou fora do ranking!!! 🧠💪<br/><br/>
                     ✅Você acertou {localStorage.getItem(configData.QUANTIDADE_ACERTOS)} de {localStorage.getItem(configData.QUANTIDADE_PARAM)}! ⏱️⚡️<br/>
                     Você levou apenas {localStorage.getItem(configData.TEMPO_PARAM)} segundos! ⏱️<br/><br/>
+                    Pontuação final: {localStorage.getItem(configData.PONTUACAO)} | Recorde: {localStorage.getItem(configData.RECORDE)}<br/><br/>
                     Compartilhe sua conquista com seus amigos e desafie-os a superar seu desempenho!<br/><br/>
 
                     🔥 Quão rápido você pode ser? Descubra em Tabuada Divertida! 💥

--- a/src/pages/Jogo/Jogo.js
+++ b/src/pages/Jogo/Jogo.js
@@ -17,9 +17,12 @@ function Jogo(){
     const[resposta, setResposta] = useState('');
     const navigate = useNavigate();
     const[loadding, setLoadding] = useState(false);
+    const[pontuacao, setPontuacao] = useState(0);
+    const[recorde, setRecorde] = useState(parseInt(localStorage.getItem(configData.RECORDE) || 0));
 
     useEffect(() => {
         localStorage.setItem(configData.QUESTOES, JSON.stringify([]));
+        localStorage.setItem(configData.PONTUACAO, 0);
         setContas1(LoadContas(parseInt(localStorage.getItem(configData.QUANTIDADE_PARAM) || 20)));
         setContas2(LoadContas(parseInt(localStorage.getItem(configData.QUANTIDADE_PARAM) || 20)));
         return() =>{
@@ -155,14 +158,28 @@ function Jogo(){
 
             localStorage.setItem(configData.QUESTOES, JSON.stringify(questoes));
 
+            let novaPontuacao = pontuacao;
+
             if(respostaCerta){
                 toast.success('Correto ✅');
                 setRespostasCorretas(respostasCorretas+1);
+                novaPontuacao += 10;
             }
             else{
                 toast.error('Incorreto 💥');
                 setRespostasIncorretas(respostasIncorretas+1);
+                if(novaPontuacao >= 5){
+                    novaPontuacao -= 5;
+                }
             }
+
+            if(novaPontuacao > recorde){
+                setRecorde(novaPontuacao);
+                localStorage.setItem(configData.RECORDE, novaPontuacao);
+            }
+
+            setPontuacao(novaPontuacao);
+            localStorage.setItem(configData.PONTUACAO, novaPontuacao);
 
             setResposta('');
             if(contador + 1 === parseInt(localStorage.getItem(configData.QUANTIDADE_PARAM) || 20)+2){
@@ -203,9 +220,11 @@ function Jogo(){
             numeroAcertos: respostasCorretas,
             numeroQuestoes: localStorage.getItem(configData.QUANTIDADE_PARAM) || 20,
             tipo: tipo,
-            tempo: localStorage.getItem(configData.TEMPO_PARAM)
+            tempo: localStorage.getItem(configData.TEMPO_PARAM),
+            pontuacao: pontuacao
         };
 
+        localStorage.setItem(configData.PONTUACAO, pontuacao);
         setLoadding(true);
         await api.post(`/ResultadosTabuadaDivertida`, data)
         .then((response) => {
@@ -247,6 +266,7 @@ function Jogo(){
                     <div>
                         <div className='tempo'>
                             <h1>🏋️ {contador-1} de {localStorage.getItem(configData.QUANTIDADE_PARAM) || 20}</h1>
+                            <h2>🎯 Pontuação: {pontuacao} | Recorde: {recorde}</h2>
                         </div>
                         <div className='info-completo'>
                             <button className='button-base' onClick={() => window.location.reload(false)}>Restart</button>

--- a/src/pages/Ranking/Ranking.js
+++ b/src/pages/Ranking/Ranking.js
@@ -127,6 +127,11 @@ function Ranking(){
                                                     Tempo
                                                 </h4>
                                             </th>
+                                            <th>
+                                                <h4>
+                                                    Pontuação
+                                                </h4>
+                                            </th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -149,6 +154,9 @@ function Ranking(){
                                                 </td>
                                                 <td>
                                                     {index === 0 ? <>🏆</> : <></>}{item.tempo}s
+                                                </td>
+                                                <td>
+                                                    {item.pontuacao}
                                                 </td>
                                             </tr>
                                         );


### PR DESCRIPTION
## Summary
- add score and record keys to Config
- track player score during each session
- display score information in game and final screen
- send player score to the API and show it on the ranking page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b7538764c832c80a26ba95abafeca