### PR TITLE
Improve responsiveness for Jogo page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -911,17 +911,18 @@ margin: 10px;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  width: 100%;
 }
 
 .divJogo h3{
-  font-size: 150px;
+  font-size: clamp(3rem, 15vw, 9rem);
 }
 
 .divJogo input{
-  align-items: center;
   text-align: center;
-  width: 50%;
-  font-size: 110px;
+  width: 100%;
+  max-width: 20rem;
+  font-size: clamp(2rem, 10vw, 6rem);
 }
 
 .rankingMultiplicacao{
@@ -1071,6 +1072,15 @@ hr{
 
 .game{
   margin-top: 2rem;
+}
+
+.game-header{
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--double-default-spacing);
+  margin-bottom: var(--double-default-spacing);
 }
 
 .resultados-lista{

--- a/src/pages/Jogo/Jogo.js
+++ b/src/pages/Jogo/Jogo.js
@@ -258,12 +258,11 @@ function Jogo(){
         )
     }
 
-    return(
-        <div className="game">
-            <div className='global-pageContainer-left'>
-                <div className='tempo'>
-                    <Tempo/>
-                    <div>
+        return(
+            <div className="game">
+                <div className='global-pageContainer-left'>
+                    <div className='game-header'>
+                        <Tempo/>
                         <div className='tempo'>
                             <h1>🏋️ {contador-1} de {localStorage.getItem(configData.QUANTIDADE_PARAM) || 20}</h1>
                             <h2>🎯 Pontuação: {pontuacao} | Recorde: {recorde}</h2>
@@ -272,16 +271,21 @@ function Jogo(){
                             <button className='button-base' onClick={() => window.location.reload(false)}>Restart</button>
                         </div>
                     </div>
-                </div>
-                <div className='divJogo'>
-                    <h3>
-                        {contasCorrente}
-                    </h3>
-                    <input type="number" value={resposta} onChange={(e) => respondeu(e.target.value)} onKeyDown={handleKeyDown} autoFocus={true}/>
+                    <div className='divJogo'>
+                        <h3>
+                            {contasCorrente}
+                        </h3>
+                        <input
+                            type="number"
+                            value={resposta}
+                            onChange={(e) => respondeu(e.target.value)}
+                            onKeyDown={handleKeyDown}
+                            autoFocus
+                        />
+                    </div>
                 </div>
             </div>
-        </div>
-    )
-}
+        )
+    }
 
 export default Jogo;


### PR DESCRIPTION
## Summary
- tweak Jogo layout for better responsiveness
- adjust question and answer font sizes using `clamp`
- add `.game-header` styles

## Testing
- `npm test -- -w 0`

------
https://chatgpt.com/codex/tasks/task_e_688b7e98c0f4832ca10e744425bac06c