### PR TITLE
Limit player name to 15 characters

### DIFF
--- a/src/pages/Formulario/Formulario.tsx
+++ b/src/pages/Formulario/Formulario.tsx
@@ -36,7 +36,7 @@ function Formulario(){
                         <h3>
                             Como você gostaria de ser chamado?👽
                         </h3>
-                        <input type="text" id="name" value={nome} onChange={(e) => {setNome(e.target.value)}}/>
+                        <input type="text" id="name" value={nome} onChange={(e) => {setNome(e.target.value)}} maxLength={15}/>
                         <h3>
                             Quantas questões?🚀
                         </h3>

--- a/src/pages/Jogo/Jogo.tsx
+++ b/src/pages/Jogo/Jogo.tsx
@@ -215,8 +215,14 @@ function Jogo(){
     }
 
     async function Finaliza(novaPontuacao){
+        const nome = String(localStorage.getItem(configData.NOME_PARAM) || '');
+        if(nome.length > 15){
+            toast.warn('Nome deve ter no máximo 15 caracteres.');
+            return;
+        }
+
         var data = {
-            nome: localStorage.getItem(configData.NOME_PARAM),
+            nome: nome,
             numeroAcertos: respostasCorretas,
             numeroQuestoes: localStorage.getItem(configData.QUANTIDADE_PARAM) || 20,
             tipo: tipo,


### PR DESCRIPTION
## Summary
- restrict name input field to 15 characters
- validate name length before submitting results to the backend

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6894a87dd788832c94294e92b859a414