### PR TITLE
Run workflow only on main branch

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-tree-093d4ef10.yml
+++ b/.github/workflows/azure-static-web-apps-witty-tree-093d4ef10.yml
@@ -4,14 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     env:
@@ -33,17 +28,3 @@ jobs:
           api_location: "" # Api source code path - optional
           output_location: "build" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    env:
-      CI: false
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WITTY_TREE_093D4EF10 }}
-          action: "close"


### PR DESCRIPTION
## Summary
- run workflow only on pushes to main branch

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*


------
https://chatgpt.com/codex/tasks/task_e_6894ab8eb8f0832c85bf5bec954a13cb