### PR TITLE
Add fireworks celebration on perfect score

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,5 +38,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
   </body>
 </html>

--- a/src/pages/Final/Final.tsx
+++ b/src/pages/Final/Final.tsx
@@ -8,8 +8,42 @@ function Final(){
     const{tipo} = useParams();
     const[questoes , setQuestoes] = useState([]);
 
+    const launchFireworks = () => {
+        const confetti = (window as any).confetti;
+        if (!confetti) return;
+
+        const duration = 3 * 1000;
+        const animationEnd = Date.now() + duration;
+        const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 0 };
+
+        const randomInRange = (min: number, max: number) => Math.random() * (max - min) + min;
+
+        const interval = setInterval(() => {
+            const timeLeft = animationEnd - Date.now();
+
+            if (timeLeft <= 0) {
+                return clearInterval(interval);
+            }
+
+            const particleCount = 50 * (timeLeft / duration);
+            confetti({
+                ...defaults,
+                particleCount,
+                origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 }
+            });
+            confetti({
+                ...defaults,
+                particleCount,
+                origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 }
+            });
+        }, 250);
+    };
+
     useEffect(() => {
         setQuestoes(JSON.parse(localStorage.getItem(configData.QUESTOES)));
+        if(localStorage.getItem(configData.QUANTIDADE_ACERTOS) === localStorage.getItem(configData.QUANTIDADE_PARAM)){
+            launchFireworks();
+        }
         return() =>{
 
         }


### PR DESCRIPTION
## Summary
- trigger fireworks animation on Final page when all questions are answered correctly
- load canvas-confetti library to display fireworks

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689df3a6fec0832c9138c8b67cf7a118