### PR TITLE
Add robot emotion to final screen

### DIFF
--- a/src/assets/robot-happy.svg
+++ b/src/assets/robot-happy.svg
@@ -1,0 +1,7 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="20" width="80" height="60" fill="#ccc" stroke="#333" />
+  <rect x="40" y="5" width="20" height="15" fill="#ccc" stroke="#333" />
+  <circle cx="35" cy="45" r="5" fill="#333" />
+  <circle cx="65" cy="45" r="5" fill="#333" />
+  <path d="M35 65 Q50 75 65 65" stroke="#333" stroke-width="4" fill="none" />
+</svg>

--- a/src/assets/robot-sad.svg
+++ b/src/assets/robot-sad.svg
@@ -1,0 +1,7 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="20" width="80" height="60" fill="#ccc" stroke="#333" />
+  <rect x="40" y="5" width="20" height="15" fill="#ccc" stroke="#333" />
+  <circle cx="35" cy="45" r="5" fill="#333" />
+  <circle cx="65" cy="45" r="5" fill="#333" />
+  <path d="M35 70 Q50 60 65 70" stroke="#333" stroke-width="4" fill="none" />
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -1218,3 +1218,9 @@ hr{
       color: var(--text-color-primary);
   }
 }
+
+.robot {
+  width: 150px;
+  display: block;
+  margin: 20px auto;
+}

--- a/src/pages/Final/Final.tsx
+++ b/src/pages/Final/Final.tsx
@@ -2,11 +2,14 @@ import {Link} from 'react-router-dom';
 import configData from "../../Config.json";
 import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import happyRobot from '../../assets/robot-happy.svg';
+import sadRobot from '../../assets/robot-sad.svg';
 
 
 function Final(){
     const{tipo} = useParams();
     const[questoes , setQuestoes] = useState([]);
+    const isPerfect = localStorage.getItem(configData.QUANTIDADE_ACERTOS) === localStorage.getItem(configData.QUANTIDADE_PARAM);
 
     const launchFireworks = () => {
         const confetti = (window as any).confetti;
@@ -41,7 +44,7 @@ function Final(){
 
     useEffect(() => {
         setQuestoes(JSON.parse(localStorage.getItem(configData.QUESTOES)));
-        if(localStorage.getItem(configData.QUANTIDADE_ACERTOS) === localStorage.getItem(configData.QUANTIDADE_PARAM)){
+        if(isPerfect){
             launchFireworks();
         }
         return() =>{
@@ -53,8 +56,9 @@ function Final(){
         <div className='global-pageContainer-left'>
             <h2><b>🎉Parabéns {localStorage.getItem(configData.NOME_PARAM)}!!!🎉</b></h2>
             <br/>
+            <img src={isPerfect ? happyRobot : sadRobot} alt={isPerfect ? 'Robô feliz' : 'Robô triste'} className='robot'/>
             {
-                localStorage.getItem(configData.QUANTIDADE_ACERTOS) == localStorage.getItem(configData.QUANTIDADE_PARAM) ?
+                isPerfect ?
                 <h3>
                     Você é um mestre da tabuada! 🧠💪<br/><br/>
                     ✅Você acertou {localStorage.getItem(configData.QUANTIDADE_ACERTOS)} de {localStorage.getItem(configData.QUANTIDADE_PARAM)} em tempo recorde! ⏱️⚡️<br/>


### PR DESCRIPTION
## Summary
- Show happy or sad robot on the final page based on player performance
- Add SVG robot assets and styles for consistent display

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689df7796d9c832c8ac4bf699d4c4198