### PR TITLE
Add direct website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Website](https://img.shields.io/website-up-down-green-red/http/shields.io.svg?label=site&url=https://www.tabuadadivertida.com/)](https://www.tabuadadivertida.com/)
 
+[Visite o site Tabuada Divertida](https://www.tabuadadivertida.com/)
+
 ## Considerações Gerais 
 
 * Site desenvolvido em HTML, JavaScript, CSS e Bootstrap conectando em uma API feita em PHP (Versão OLD)


### PR DESCRIPTION
## Summary
- add explicit link to Tabuada Divertida website in README

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a31a719908832c8f596b22db6823d7