### PR TITLE
Add Google AdSense script to site head

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Tabuada Divertida</title>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3347108086327951" crossorigin="anonymous"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Summary
- add Google AdSense script to HTML head

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68adcebc38b0832c8d79e92f5ace0faf