### PR TITLE
Show total players on ranking page

### DIFF
--- a/src/pages/Ranking/Ranking.tsx
+++ b/src/pages/Ranking/Ranking.tsx
@@ -12,7 +12,6 @@ function Ranking(){
     const[quantidade, setQuantidade] = useState([]);
     const[openQuantidades, setOpenQuantidades] = useState<Record<number, boolean>>({});
     const[quantidadeTetativas, setQuantidadeTentativas] = useState([]);
-    const[quantidadeRanking, setQuantidadeRanking] = useState([]);
     const[type, setType] = useState('M');
     const[loadding, setLoadding] = useState(true);
     const [filtroNome, setFiltroNome] = useState('');
@@ -30,7 +29,6 @@ function Ranking(){
                 });
                 setOpenQuantidades(openObj);
                 setQuantidadeTentativas(response.data.total);
-                setQuantidadeRanking(response.data.quantity);
                 setLoadding(false);
             }).catch(() => {
                 navigate('/', {replace: true});
@@ -74,8 +72,7 @@ function Ranking(){
             </h1>
             <br/>
             <div className='rankingText'>
-                <h3>Conheça nossos melhores jogadores!!😎 🥳</h3>
-                <h3>🔥Apenas {quantidadeRanking} de {quantidadeTetativas} jogadores conseguiram entrar no ranking!!🔥</h3>
+                <h3>🔥Total de jogadores: {quantidadeTetativas}🔥</h3>
                 <br/>
                 <br/>
                 <div className='botoesRanking'>


### PR DESCRIPTION
## Summary
- replace ranking header message to display total number of players
- remove unused ranking count handling
- drop extra ranking introduction line

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aeedaac4dc832c88908f5d5baf490e