### PR TITLE
Add pre-game countdown screen

### DIFF
--- a/src/pages/Contagem/Contagem.css
+++ b/src/pages/Contagem/Contagem.css
@@ -1,0 +1,28 @@
+.countdown-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    width: 100%;
+    background-color: var(--color-surface);
+}
+
+.countdown-text {
+    font-size: 24px;
+    margin-bottom: 20px;
+    color: var(--text-color-primary);
+}
+
+.countdown-number {
+    font-size: 120px;
+    font-weight: bold;
+    color: var(--primary-color);
+    animation: pulse 1s ease-in-out;
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.4); }
+    100% { transform: scale(1); }
+}

--- a/src/pages/Contagem/Contagem.css
+++ b/src/pages/Contagem/Contagem.css
@@ -9,15 +9,15 @@
 }
 
 .countdown-text {
-    font-size: 24px;
+    font-size: 4rem;
     margin-bottom: 20px;
     color: var(--text-color-primary);
 }
 
 .countdown-number {
-    font-size: 120px;
+    font-size: 16rem;
     font-weight: bold;
-    color: var(--primary-color);
+    color: var(--text-color-primary);
     animation: pulse 1s ease-in-out;
 }
 

--- a/src/pages/Contagem/Contagem.tsx
+++ b/src/pages/Contagem/Contagem.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import './Contagem.css';
+
+function Contagem(){
+    const { tipo } = useParams();
+    const navigate = useNavigate();
+    const [contador, setContador] = useState(3);
+
+    useEffect(() => {
+        const timer = setInterval(() => {
+            setContador((prev) => prev - 1);
+        }, 1000);
+        return () => clearInterval(timer);
+    }, []);
+
+    useEffect(() => {
+        if (contador === 0) {
+            navigate(`/jogo/${tipo}`);
+        }
+    }, [contador, navigate, tipo]);
+
+    return (
+        <div className='countdown-container'>
+            <h2 className='countdown-text'>Prepare-se!</h2>
+            {contador > 0 && (
+                <div key={contador} className='countdown-number'>{contador}</div>
+            )}
+        </div>
+    );
+}
+
+export default Contagem;

--- a/src/pages/Final/Final.tsx
+++ b/src/pages/Final/Final.tsx
@@ -108,7 +108,7 @@ function Final(){
             </div>
 
             <div className='botoes'>
-                <Link className='global-button global-button--full-width' to={`/jogo/` + tipo}>Jogar novamente</Link>
+                <Link className='global-button global-button--full-width' to={`/contagem/` + tipo}>Jogar novamente</Link>
                 <Link className='global-button global-button--full-width' to={`/ranking`}>Ranking</Link>
                 <Link className='global-button global-button--full-width' to="/historico">Histórico</Link>
                 <Link className='global-button global-button--full-width' to="/">Início</Link>

--- a/src/pages/TipoJogo/TipoJogo.tsx
+++ b/src/pages/TipoJogo/TipoJogo.tsx
@@ -7,11 +7,11 @@ function TipoJogo(){
             <div className='global-pageContainer-left'>
                 <div className='botoes'>
                     <h3> Selecione a operação matemática que deseja jogar ➕ ➖ ✖️ ➗ 🔢</h3>
-                    <Link to={`/jogo/M`} className='global-button global-button--full-width'>Multiplicação✖️</Link>
-                    <Link to={`/jogo/A`} className='global-button global-button--full-width'>Adição➕</Link>
-                    <Link to={`/jogo/S`} className='global-button global-button--full-width'>Subtração➖</Link>
-                    <Link to={`/jogo/D`} className='global-button global-button--full-width'>Divisão➗</Link>
-                    <Link to={`/jogo/R`} className='global-button global-button--full-width'>Aleatório🔀</Link>
+                    <Link to={`/contagem/M`} className='global-button global-button--full-width'>Multiplicação✖️</Link>
+                    <Link to={`/contagem/A`} className='global-button global-button--full-width'>Adição➕</Link>
+                    <Link to={`/contagem/S`} className='global-button global-button--full-width'>Subtração➖</Link>
+                    <Link to={`/contagem/D`} className='global-button global-button--full-width'>Divisão➗</Link>
+                    <Link to={`/contagem/R`} className='global-button global-button--full-width'>Aleatório🔀</Link>
                     <Link to={`/formulario`} className='global-button global-button--full-width global-button--back'>Voltar</Link>
                 </div>
             </div>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,6 +2,7 @@ import {BrowserRouter, Routes, Route} from 'react-router-dom';
 import Home from './pages/Home/Home';
 import Formulario from './pages/Formulario/Formulario';
 import TipoJogo from './pages/TipoJogo/TipoJogo';
+import Contagem from './pages/Contagem/Contagem';
 import Jogo from './pages/Jogo/Jogo';
 import Final from './pages/Final/Final';
 import Ranking from './pages/Ranking/Ranking';
@@ -21,6 +22,7 @@ function RoutesApp(){
                 <Route path='/' element={<Home/>}/>
                 <Route path='/formulario' element={<Formulario/>}/>
                 <Route path='/selecionarjogo' element={<TipoJogo/>}/>
+                <Route path='/contagem/:tipo' element={<Contagem/>}/>
                 <Route path='/jogo/:tipo' element={<Jogo/>}/>
                 <Route path='/ranking' element={<Ranking/>}/>
                 <Route path='/final/:tipo' element={<Final/>}/>


### PR DESCRIPTION
## Summary
- add animated countdown screen before starting gameplay
- link game selection to countdown before routing to game
- register countdown page in router

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b85d4af34c832c84e6cd4f25cb2301