### PR TITLE
feat: update navbar option colors

### DIFF
--- a/src/components/Header/style.css
+++ b/src/components/Header/style.css
@@ -18,9 +18,10 @@
 .ranking{
     text-decoration: none;
     cursor: pointer;
-    background-color: var(--button-color-primary-right);
+    background-color: var(--button-color-primary);
     padding: 5px 14px;
-    color: var(--text-color-primary-light);
+    color: var(--text-color-primary);
+    font-weight: bold;
     border-radius: 5px;
 }
 


### PR DESCRIPTION
## Summary
- use theme colors for Ranking and Histórico navigation links

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b86134d914832ca82006fd6327e205