### PR TITLE
Add light and dark theme toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "tabuadadivertida",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/free-solid-svg-icons": "^7.0.1",
+        "@fortawesome/react-fontawesome": "^3.0.2",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2168,6 +2170,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.1.tgz",
+      "integrity": "sha512-0VpNtO5cNe1/HQWMkl4OdncYK/mv9hnBte0Ew0n6DMzmo3Q3WzDFABHm6LeNTipt5zAyhQ6Ugjiu8aLaEjh1gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.1.tgz",
+      "integrity": "sha512-x0cR55ILVqFpUioSMf6ebpRCMXMcheGN743P05W2RB5uCNpJUqWIqW66Lap8PfL/lngvjTbZj0BNSUweIr/fHQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.0.1.tgz",
+      "integrity": "sha512-esKuSrl1WMOTMDLNt38i16VfLe/gRZt2ZAJ3Yw7slfs7sj583MKqNFqO57zmhknk1Sya6f9Wys89aCzIJkcqlg==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.0.2.tgz",
+      "integrity": "sha512-cmp/nT0pPC7HUALF8uc3+D5ECwEBWxYQbOIHwtGUWEu72sWtZc26k5onr920HWOViF0nYaC+Qzz6Ln56SQcaVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -18405,6 +18454,34 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.1.tgz",
+      "integrity": "sha512-0VpNtO5cNe1/HQWMkl4OdncYK/mv9hnBte0Ew0n6DMzmo3Q3WzDFABHm6LeNTipt5zAyhQ6Ugjiu8aLaEjh1gg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.1.tgz",
+      "integrity": "sha512-x0cR55ILVqFpUioSMf6ebpRCMXMcheGN743P05W2RB5uCNpJUqWIqW66Lap8PfL/lngvjTbZj0BNSUweIr/fHQ==",
+      "peer": true,
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "7.0.1"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.0.1.tgz",
+      "integrity": "sha512-esKuSrl1WMOTMDLNt38i16VfLe/gRZt2ZAJ3Yw7slfs7sj583MKqNFqO57zmhknk1Sya6f9Wys89aCzIJkcqlg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "7.0.1"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.0.2.tgz",
+      "integrity": "sha512-cmp/nT0pPC7HUALF8uc3+D5ECwEBWxYQbOIHwtGUWEu72sWtZc26k5onr920HWOViF0nYaC+Qzz6Ln56SQcaVg==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/free-solid-svg-icons": "^7.0.1",
+    "@fortawesome/react-fontawesome": "^3.0.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
@@ -14,8 +16,8 @@
     "react-router-dom": "^6.3.0",
     "react-scripts": "^5.0.1",
     "react-toastify": "^9.0.7",
-    "web-vitals": "^2.1.4",
-    "typescript": "4.7.4"
+    "typescript": "4.7.4",
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,29 @@
 import RoutesApp from "./routes";
-import {ToastContainer} from 'react-toastify';
+import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Footer from './components/footer';
+import { useEffect, useState } from 'react';
 
 function App() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    const saved = localStorage.getItem('theme');
+    return saved === 'dark' ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    document.body.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
   return (
     <div className="app">
-      <ToastContainer autoClose={1000}/>
-      <RoutesApp/>
-      <Footer/>
+      <ToastContainer autoClose={1000} />
+      <RoutesApp theme={theme} toggleTheme={toggleTheme} />
+      <Footer />
     </div>
   );
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,3 +1,4 @@
+import ThemeSwitcher from '../ThemeSwitcher/themeSwitcher';
 import './style.css';
 import { Link } from 'react-router-dom';
 
@@ -12,11 +13,9 @@ function Header({ theme, toggleTheme }: HeaderProps){
             <div className='toolNav'>
                 <Link className='logo' to='/'>Tabuada Divertida</Link>
                 <div className='opcoes-head'>
-                    <button className='theme-toggle' onClick={toggleTheme}>
-                        {theme === 'light' ? '🌙' : '☀️'}
-                    </button>
                     <Link className='ranking' to='/ranking'>🔝Ranking🔝</Link>
                     <Link className='ranking' to='/historico'>🔝Histórico🔝</Link>
+                    <ThemeSwitcher theme={theme} toggleTheme={toggleTheme} />
                 </div>
             </div>
         </header>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,12 +1,20 @@
 import './style.css';
-import {Link} from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-function Header(){
+interface HeaderProps {
+    theme: 'light' | 'dark';
+    toggleTheme: () => void;
+}
+
+function Header({ theme, toggleTheme }: HeaderProps){
     return(
         <header className='conNav'>
             <div className='toolNav'>
                 <Link className='logo' to='/'>Tabuada Divertida</Link>
                 <div className='opcoes-head'>
+                    <button className='theme-toggle' onClick={toggleTheme}>
+                        {theme === 'light' ? '🌙' : '☀️'}
+                    </button>
                     <Link className='ranking' to='/ranking'>🔝Ranking🔝</Link>
                     <Link className='ranking' to='/historico'>🔝Histórico🔝</Link>
                 </div>

--- a/src/components/Header/style.css
+++ b/src/components/Header/style.css
@@ -24,7 +24,22 @@
     font-weight: bold;
     border-radius: 5px;
 }
+.opcoes-head {
+    display: flex;
+    align-items: center;
+}
 
-.opcoes-head a{
+.theme-toggle {
+    background-color: var(--button-color-primary);
+    border: none;
+    padding: 5px 14px;
+    color: var(--text-color-primary);
+    font-weight: bold;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.opcoes-head a,
+.opcoes-head button{
     margin-right: 8px;
 }

--- a/src/components/Header/style.css
+++ b/src/components/Header/style.css
@@ -27,6 +27,8 @@
 .opcoes-head {
     display: flex;
     align-items: center;
+    min-width: 16rem;
+    gap: var(--default-spacing);
 }
 
 .theme-toggle {
@@ -42,4 +44,20 @@
 .opcoes-head a,
 .opcoes-head button{
     margin-right: 8px;
+}
+
+@media screen and (max-width: 1000px){
+    .opcoes-head a,
+    .opcoes-head button{
+        display: none;
+    }
+
+    .opcoes-head {
+        justify-content: end;
+        margin-right: var(--default-spacing);
+    }
+
+    .toolNav a {
+        margin-left: var(--default-spacing);
+    }
 }

--- a/src/components/ThemeSwitcher/themeSwitcher.css
+++ b/src/components/ThemeSwitcher/themeSwitcher.css
@@ -1,0 +1,31 @@
+.change-theme-div {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid grey;
+    border-radius: 30%;
+  }
+  
+  input[type="radio"] {
+    display: none;
+  }
+  
+  .theme-label {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--icon-heigth);
+    height: var(--icon-heigth);
+    border-radius: 30%;
+    transition: background-color 0.3s ease-in-out, transform 0.3s ease-in-out;
+  }
+  
+  input[type="radio"]:checked + .theme-label {
+    background-color: var(--transient-color-primary);
+    transform: scale(1.1);
+  }
+  
+  input[type="radio"]:not(:checked) + .theme-label:hover {
+    background-color: var(--transient-color-second);
+  }

--- a/src/components/ThemeSwitcher/themeSwitcher.tsx
+++ b/src/components/ThemeSwitcher/themeSwitcher.tsx
@@ -1,0 +1,40 @@
+import './themeSwitcher.css';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSun, faMoon } from '@fortawesome/free-solid-svg-icons';
+
+interface HeaderProps {
+    theme: 'light' | 'dark';
+    toggleTheme: () => void;
+}
+
+const ThemeSwitcher = ({ theme, toggleTheme }: HeaderProps) => {
+    return (
+        <div className="change-theme-div">
+            <input
+                type="radio"
+                id="light"
+                name="theme"
+                value="light"
+                checked={theme === 'light'}
+                onChange={toggleTheme}
+            />
+            <label htmlFor="light" className="theme-label">
+                <FontAwesomeIcon icon={faSun} className="icon sun" />
+            </label>
+
+            <input
+                type="radio"
+                id="dark"
+                name="theme"
+                value="dark"
+                checked={theme === 'dark'}
+                onChange={toggleTheme}
+            />
+            <label htmlFor="dark" className="theme-label">
+                <FontAwesomeIcon icon={faMoon} className="icon moon" />
+            </label>
+        </div>
+    );
+};
+
+export default ThemeSwitcher;

--- a/src/index.css
+++ b/src/index.css
@@ -53,14 +53,17 @@
   --default-border-radius: 8px;
   --default-border-radius-extra: 16px;
   --shadow-color-primary: rgba(0, 0, 0, 0.2);
+  --icon-heigth:24px;
+
+  --transient-color-primary: #afafaf;
 }
 
 [data-theme='dark'] {
-  --background-color: #111827;
-  --primary-color: #1F2937;
+  --background-color: #06080e;
+  --primary-color: #131922;
   --secundary-color: #374151;
   --text-color-primary-light: #1F2937;
-  --button-color-primary: #4B5563;
+  --button-color-primary: #38404b;
   --button-color-primary-hover: #6B7280;
   --button-color-primary-wrong: #B91C1C;
   --button-color-primary-wrong-hover: #991B1B;
@@ -80,6 +83,8 @@
   --panel-border-color: #4B5563;
   --modal-background-color: rgba(0, 0, 0, 0.95);
   --shadow-color-primary: rgba(0, 0, 0, 0.7);
+
+  --transient-color-primary: #38404b;
 }
 
 * {

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,34 @@
 
   --default-border-radius: 8px;
   --default-border-radius-extra: 16px;
+  --shadow-color-primary: rgba(0, 0, 0, 0.2);
+}
+
+[data-theme='dark'] {
+  --background-color: #111827;
+  --primary-color: #1F2937;
+  --secundary-color: #374151;
+  --text-color-primary-light: #1F2937;
+  --button-color-primary: #4B5563;
+  --button-color-primary-hover: #6B7280;
+  --button-color-primary-wrong: #B91C1C;
+  --button-color-primary-wrong-hover: #991B1B;
+  --button-color-primary-right: #15803D;
+  --button-color-primary-right-hover: #166534;
+  --button-color-back: #6B7280;
+  --button-color-back-hover: #6B7280;
+  --text-color-primary: #F9FAFB;
+  --text-color-secondary: #F3F4F6;
+  --button-color-secondary: #6B7280;
+  --separator-color-primary: rgba(156, 163, 175, 0.48);
+  --block-color: #1F2937;
+  --block-color-secundary: #374151;
+  --color-surface: #374151;
+  --color-surface-variant: #4B5563;
+  --loader-color: #3B82F6;
+  --panel-border-color: #4B5563;
+  --modal-background-color: rgba(0, 0, 0, 0.95);
+  --shadow-color-primary: rgba(0, 0, 0, 0.7);
 }
 
 * {

--- a/src/index.css
+++ b/src/index.css
@@ -416,10 +416,6 @@ footer a {
   font-size: 19px;
 }
 
-.dadosResumidos{
-  
-}
-
 .dados{
   width: 100%;
 }
@@ -442,9 +438,6 @@ footer a {
 
 .descricao + .descricao{
   margin-top: 16px;
-}
-
-.descricao h4{
 }
 
 .dadosResumidos a{

--- a/src/pages/Contagem/Contagem.css
+++ b/src/pages/Contagem/Contagem.css
@@ -5,7 +5,6 @@
     align-items: center;
     height: 100vh;
     width: 100%;
-    background-color: var(--color-surface);
 }
 
 .countdown-text {

--- a/src/pages/Contagem/Contagem.tsx
+++ b/src/pages/Contagem/Contagem.tsx
@@ -21,7 +21,7 @@ function Contagem(){
     }, [contador, navigate, tipo]);
 
     return (
-        <div className='countdown-container'>
+        <div className='countdown-container global-pageContainer-left'>
             <h2 className='countdown-text'>Prepare-se!</h2>
             {contador > 0 && (
                 <div key={contador} className='countdown-number'>{contador}</div>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,4 @@
-import {BrowserRouter, Routes, Route} from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home/Home';
 import Formulario from './pages/Formulario/Formulario';
 import TipoJogo from './pages/TipoJogo/TipoJogo';
@@ -14,10 +14,15 @@ import Sobre from './pages/Sobre/Sobre';
 import Contato from './pages/Contato/Contato';
 import Header from './components/Header/index';
 
-function RoutesApp(){
+interface RoutesAppProps {
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
+}
+
+function RoutesApp({ theme, toggleTheme }: RoutesAppProps) {
     return(
         <BrowserRouter>
-            <Header/>
+            <Header theme={theme} toggleTheme={toggleTheme}/>
             <Routes>
                 <Route path='/' element={<Home/>}/>
                 <Route path='/formulario' element={<Formulario/>}/>


### PR DESCRIPTION
## Summary
- support light and dark themes via CSS variables
- add theme toggle button in header
- persist theme selection in localStorage

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b862ca41c0832cb96f1b5392d6344f