### PR TITLE
feat: add colorful background and button effects

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -56,6 +56,10 @@
   --icon-heigth:24px;
 
   --transient-color-primary: #afafaf;
+
+  /* Gradiente vibrante e sombra dos botões */
+  --background-gradient: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
+  --button-shadow-color: rgba(0, 0, 0, 0.25);
 }
 
 [data-theme='dark'] {
@@ -85,6 +89,10 @@
   --shadow-color-primary: rgba(0, 0, 0, 0.7);
 
   --transient-color-primary: #38404b;
+
+  /* Gradiente vibrante e sombra dos botões no modo escuro */
+  --background-gradient: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+  --button-shadow-color: rgba(0, 0, 0, 0.7);
 }
 
 * {
@@ -95,7 +103,7 @@
 
 body {
   font-family: sans-serif;
-  background-color: var(--background-color);
+  background: var(--background-gradient);
   color: var(--text-color-primary);
   width: 100%;
   height: 100%;
@@ -614,11 +622,12 @@ footer a {
   padding: 10px;
   border-radius: 4px;
   cursor: pointer;
-  transition: all 0.5s;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.5s ease;
   background-color: var(--button-color-primary);
   color: var(--text-color-secondary);
   font-weight: bold;
   border: none;
+  box-shadow: 0 4px 0 var(--button-shadow-color);
 }
 
 .global-button-wrong{
@@ -631,16 +640,19 @@ footer a {
   padding: 10px;
   border-radius: 4px;
   cursor: pointer;
-  transition: all 0.5s;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.5s ease;
   color: var(--text-color-secondary);
   font-weight: bold;
   border: none;
   background-color: var(--button-color-primary-wrong);
+  box-shadow: 0 4px 0 var(--button-shadow-color);
 }
 
 
 .global-button-wrong:hover{
   background-color: var(--button-color-primary-wrong-hover);
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 8px 0 var(--button-shadow-color);
 }
 
 .global-button-right{
@@ -653,21 +665,32 @@ footer a {
   padding: 10px;
   border-radius: 4px;
   cursor: pointer;
-  transition: all 0.5s;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.5s ease;
   color: var(--text-color-secondary);
   font-weight: bold;
   border: none;
   background-color: var(--button-color-primary-right);
+  box-shadow: 0 4px 0 var(--button-shadow-color);
 }
 
 .global-button-right:hover{
   background-color: var(--button-color-primary-right-hover);
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 8px 0 var(--button-shadow-color);
 }
 
 
 .global-button:hover{
-
   background-color: var(--button-color-primary-hover);
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 8px 0 var(--button-shadow-color);
+}
+
+.global-button:active,
+.global-button-wrong:active,
+.global-button-right:active{
+  transform: translateY(0) scale(0.95);
+  box-shadow: 0 2px 0 var(--button-shadow-color);
 }
 
 .global-button--full-width{


### PR DESCRIPTION
## Summary
- add vibrant gradient backgrounds for light and dark themes
- animate buttons with hover/active scaling and shadows

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bb30b19628832c8d02a5f7fac830e3