### PR TITLE
Add Contribua support page and footer link

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -46,6 +46,11 @@
     <priority>0.60</priority>
   </url>
   <url>
+    <loc>https://www.tabuadadivertida.com/contribua</loc>
+    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <priority>0.65</priority>
+  </url>
+  <url>
     <loc>https://www.tabuadadivertida.com/contagem/M</loc>
     <lastmod>2025-09-19T13:01:21+00:00</lastmod>
     <priority>0.70</priority>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -3,15 +3,13 @@ import './style.css';
 function Footer(){
     return(
         <footer>
-            <div className='support-option'>
-                <a className='support-option__link' href='/contribua'>💜 Contribua com o projeto</a>
-            </div>
             <h1><a target='_blank' rel='noreferrer' href='http://www.sunsalesystem.com.br/' >SunSale System</a></h1>
             <div className='links'>
                 <h3>
                     <a href='/privacidade'>Política de Privacidade</a>
                     <a href='/sobre'>Sobre</a>
                     <a href='/contato'>Contato</a>
+                    <a href='/contribua'>💜 Contribua com o projeto</a>
                 </h3>
             </div>
         </footer>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -3,6 +3,9 @@ import './style.css';
 function Footer(){
     return(
         <footer>
+            <div className='support-option'>
+                <a className='support-option__link' href='/contribua'>💜 Contribua com o projeto</a>
+            </div>
             <h1><a target='_blank' rel='noreferrer' href='http://www.sunsalesystem.com.br/' >SunSale System</a></h1>
             <div className='links'>
                 <h3>

--- a/src/components/footer/style.css
+++ b/src/components/footer/style.css
@@ -9,11 +9,33 @@ footer{
     background-color: #121212;
     opacity : 0.9;
     box-shadow: 0 -3px 5px -1px #0003, 0 -6px 10px #00000024, 0 -1px 18px #0000001f;
+    padding: 16px 12px 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
 }
 
 footer a{
     color: white;
     text-decoration: none;
+}
+
+.support-option__link{
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px 20px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #7c3aed, #ec4899);
+    font-size: 14px;
+    font-weight: 600;
+    transition: filter 0.3s ease;
+}
+
+.support-option__link:hover{
+    filter: brightness(1.1);
 }
 
 .links{

--- a/src/index.css
+++ b/src/index.css
@@ -41,7 +41,7 @@
 
   --modal-background-color: rgba(255, 255, 255, 0.95);
 
-  --footer-heigth: 48px;
+  --footer-heigth: 128px;
 
   /* Espaçamentos padrões */
   --default-spacing: 8px;
@@ -711,7 +711,7 @@ footer a {
   flex-direction: column;
   margin-top: 8px;
   height: 100%;
-  margin-bottom: 48px;
+  margin-bottom: var(--footer-heigth);
   padding: 20px 8px;
   color: var(--text-color-primary);
   max-width: 1080px;
@@ -722,7 +722,7 @@ footer a {
   display: flex;
   flex-direction: column;
   margin-top: 8px;
-  margin-bottom: 48px;
+  margin-bottom: var(--footer-heigth);
   padding: 20px 8px;
   color: var(--text-color-primary);
   max-width: 1080px;
@@ -733,7 +733,7 @@ footer a {
   display: flex;
   flex-direction: column;
   margin-top: 8px;
-  margin-bottom: 48px;
+  margin-bottom: var(--footer-heigth);
   padding: 20px 8px;
   color: var(--text-color-primary);
   width: 100%;
@@ -741,7 +741,7 @@ footer a {
 }
 
 .global-extraBottom{
-  margin-bottom: 80px;
+  margin-bottom: calc(var(--footer-heigth) + 32px);
 }
 
 .todasRespostas{

--- a/src/pages/Contribua/Contribua.css
+++ b/src/pages/Contribua/Contribua.css
@@ -1,0 +1,47 @@
+.contribute-container {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--block-color);
+    color: var(--text-color-primary);
+    gap: var(--double-default-spacing);
+    border-radius: var(--default-border-radius);
+    padding: var(--triple-default-spacing);
+    max-width: 640px;
+    margin: 0 auto;
+    box-shadow: 0 2px 5px var(--shadow-color-primary);
+    line-height: 1.6;
+}
+
+.contribute-container h1,
+.contribute-container h2 {
+    color: var(--text-color-primary);
+}
+
+.contribute-container p {
+    font-size: 16px;
+    color: var(--text-color-primary);
+    line-height: 1.6;
+    text-align: justify;
+}
+
+.contribute-container ul {
+    padding-left: 1.5rem;
+    list-style-type: disc;
+    color: var(--text-color-primary);
+}
+
+.contribute-container li {
+    margin-bottom: 8px;
+    font-size: 15px;
+}
+
+.contribute-highlight {
+    font-weight: bold;
+    color: var(--button-color-primary);
+}
+
+.contribute-footer {
+    margin-top: var(--double-default-spacing);
+    text-align: center;
+    font-style: italic;
+}

--- a/src/pages/Contribua/Contribua.tsx
+++ b/src/pages/Contribua/Contribua.tsx
@@ -1,0 +1,33 @@
+function Contribua() {
+    return (
+        <div className="global-pageContainer-left">
+            <h1>Contribua com o projeto 💜</h1>
+            <p className="global-mt">
+                O <strong>Tabuada Divertida</strong> é um projeto gratuito, feito com carinho para ajudar estudantes a praticarem matemática de forma leve e divertida.
+            </p>
+            <p className="global-mt">
+                Se você gostou do site e quiser apoiar o projeto, qualquer contribuição é muito bem-vinda!
+            </p>
+
+            <h2 className="global-mt">💸 Faça uma doação:</h2>
+            <ul className="global-mt">
+                <li><strong>Pix:</strong> rodrigoborgesmachado@gmail.com</li>
+                <li><strong>PicPay:</strong> @RodrigoMachado</li>
+                <li><strong>PayPal:</strong> paypal.me/rodrigomachado</li>
+            </ul>
+
+            <h2 className="global-mt">🤝 Outras formas de ajudar:</h2>
+            <ul className="global-mt">
+                <li>Compartilhe o site com amigos, familiares e professores</li>
+                <li>Divulgue nas redes sociais ou grupos escolares</li>
+                <li>Envie sugestões ou feedbacks</li>
+            </ul>
+
+            <p className="global-mt">
+                Obrigado por fazer parte dessa jornada! 💙
+            </p>
+        </div>
+    );
+}
+
+export default Contribua;

--- a/src/pages/Contribua/Contribua.tsx
+++ b/src/pages/Contribua/Contribua.tsx
@@ -1,33 +1,35 @@
+import './Contribua.css';
+
 function Contribua() {
-    return (
-        <div className="global-pageContainer-left">
-            <h1>Contribua com o projeto 💜</h1>
-            <p className="global-mt">
-                O <strong>Tabuada Divertida</strong> é um projeto gratuito, feito com carinho para ajudar estudantes a praticarem matemática de forma leve e divertida.
-            </p>
-            <p className="global-mt">
-                Se você gostou do site e quiser apoiar o projeto, qualquer contribuição é muito bem-vinda!
-            </p>
+  return (
+    <div className="global-pageContainer-left">
+      <div className="contribute-container">
+        <h1>Contribua com o projeto 💜</h1>
+        <p>
+          O <strong>Tabuada Divertida</strong> é um projeto gratuito, feito com carinho para ajudar estudantes a praticarem matemática de forma leve e divertida.
+        </p>
+        <p>
+          Se você gostou do site e quiser apoiar o projeto, qualquer contribuição é muito bem-vinda!
+        </p>
 
-            <h2 className="global-mt">💸 Faça uma doação:</h2>
-            <ul className="global-mt">
-                <li><strong>Pix:</strong> rodrigoborgesmachado@gmail.com</li>
-                <li><strong>PicPay:</strong> @RodrigoMachado</li>
-                <li><strong>PayPal:</strong> paypal.me/rodrigomachado</li>
-            </ul>
+        <h2>💸 Faça uma doação:</h2>
+        <ul>
+          <li><span>Pix:</span> rodrigoborgesmachado@gmail.com</li>
+        </ul>
 
-            <h2 className="global-mt">🤝 Outras formas de ajudar:</h2>
-            <ul className="global-mt">
-                <li>Compartilhe o site com amigos, familiares e professores</li>
-                <li>Divulgue nas redes sociais ou grupos escolares</li>
-                <li>Envie sugestões ou feedbacks</li>
-            </ul>
+        <h2>🤝 Outras formas de ajudar:</h2>
+        <ul>
+          <li>Compartilhe o site com amigos, familiares e professores</li>
+          <li>Divulgue nas redes sociais ou grupos escolares</li>
+          <li>Envie sugestões ou feedbacks</li>
+        </ul>
 
-            <p className="global-mt">
-                Obrigado por fazer parte dessa jornada! 💙
-            </p>
-        </div>
-    );
+        <p className="contribute-footer">
+          Obrigado por fazer parte dessa jornada! 💙
+        </p>
+      </div>
+    </div>
+  );
 }
 
 export default Contribua;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,6 +12,7 @@ import Historico from './pages/Historico/Historico';
 import PoliticaPrivacidade from './pages/PoliticaPrivacidade/PoliticaPrivacidade';
 import Sobre from './pages/Sobre/Sobre';
 import Contato from './pages/Contato/Contato';
+import Contribua from './pages/Contribua/Contribua';
 import Header from './components/Header/index';
 import AprenderMatematicaJogos from './pages/Artigos/AprenderMatematicaJogos';
 
@@ -38,6 +39,7 @@ function RoutesApp({ theme, toggleTheme }: RoutesAppProps) {
                 <Route path='/sobre' element={<Sobre/>}/>
                 <Route path='/contato' element={<Contato/>}/>
                 <Route path='/artigos/aprender-matematica-com-jogos' element={<AprenderMatematicaJogos/>}/>
+                <Route path='/contribua' element={<Contribua/>}/>
                 <Route path='*' element={<Erro/>}/>
             </Routes>
         </BrowserRouter>


### PR DESCRIPTION
## Summary
- add a Contribua page that explains how users can support the project and make donations
- surface the new page across the app by exposing the route, updating the footer CTA, and adjusting layout spacing
- register the Contribua URL in the public sitemap for discoverability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd63362dfc832c85fc7aaa02017d03