### PR TITLE
Add static web app configuration and refresh sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,127 +2,132 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.tabuadadivertida.com/</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/selecionarjogo</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/formulario</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/ranking</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/historico</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.75</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/instrucoes</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.75</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/privacidade</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.60</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/sobre</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.60</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/contato</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.60</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/contribua</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
+    <priority>0.65</priority>
+  </url>
+  <url>
+    <loc>https://www.tabuadadivertida.com/artigos/aprender-matematica-com-jogos</loc>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.65</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/contagem/M</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/contagem/A</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/contagem/S</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/contagem/D</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/contagem/R</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/jogo/M</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/jogo/A</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/jogo/S</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/jogo/D</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/jogo/R</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.70</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/final/M</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.60</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/final/A</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.60</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/final/S</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.60</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/final/D</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.60</priority>
   </url>
   <url>
     <loc>https://www.tabuadadivertida.com/final/R</loc>
-    <lastmod>2025-09-19T13:01:21+00:00</lastmod>
+    <lastmod>2025-09-22T14:17:05+00:00</lastmod>
     <priority>0.60</priority>
   </url>
 </urlset>

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,30 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/assets/*",
+      "/img/*",
+      "/static/*",
+      "/*.css",
+      "/*.js",
+      "/*.map",
+      "/*.png",
+      "/*.jpg",
+      "/*.jpeg",
+      "/*.svg",
+      "/favicon.ico",
+      "/robots.txt",
+      "/sitemap.xml"
+    ]
+  },
+  "responseOverrides": {
+    "404": { "rewrite": "/index.html" }
+  },
+  "globalHeaders": {
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-Content-Type-Options": "nosniff"
+  },
+  "routes": [
+    { "route": "/index.html", "redirect": "/", "statusCode": 301 }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Azure Static Web Apps configuration with navigation fallback, response override, and security headers
- refresh sitemap to cover current tabuadadivertida.com routes and update metadata

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d159eb7c54832c9211228a57a0e110