### PR TITLE
Add História da Tabuada article and navigation updates

### DIFF
--- a/src/pages/Artigos/Artigos.tsx
+++ b/src/pages/Artigos/Artigos.tsx
@@ -11,6 +11,11 @@ function Artigos(){
                             Aprenda Matemática com jogos
                         </span>
                     </Link>
+                    <Link to={`/artigos/historia-da-tabuada`} className='global-button global-button--full-width'>
+                        <span className='option-link'>
+                            História da Tabuada
+                        </span>
+                    </Link>
                     <Link to={`/tabuada`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             Tabuada de Multiplicação e Divisão

--- a/src/pages/Artigos/HistoriaTabuada.tsx
+++ b/src/pages/Artigos/HistoriaTabuada.tsx
@@ -1,0 +1,82 @@
+import { Link } from 'react-router-dom';
+
+function HistoriaTabuada() {
+    return (
+        <div className='global-pageContainer options-preview'>
+            <header className='tabuada-description'>
+                <h1>📜 A História da Tabuada</h1>
+                <p>
+                    A tabuada acompanha a humanidade desde as primeiras civilizações que precisaram registrar trocas comerciais
+                    e observações astronômicas. Ao longo dos séculos, ela ganhou diferentes formatos e permanece, até hoje, como
+                    uma aliada essencial para quem deseja realizar cálculos com agilidade.
+                </p>
+            </header>
+
+            <section className='tabuada-description'>
+                <h2>🏛️ As raízes na Antiguidade</h2>
+                <p>
+                    Povos como os <strong>babilônios</strong> e os <strong>egípcios</strong> já organizavam tabelas com resultados
+                    de multiplicações para facilitar o dia a dia. Essas primeiras tabuadas eram gravadas em tábuas de argila ou
+                    papiros e ajudavam mercadores, artesãos e estudiosos a manter seus registros com precisão.
+                </p>
+                <p>
+                    Outros povos, como os <strong>chineses</strong> e <strong>indianos</strong>, também criaram métodos visuais e
+                    músicas para memorização. Isso mostra que, independentemente da cultura, aprender padrões numéricos sempre foi
+                    fundamental para resolver problemas práticos.
+                </p>
+            </section>
+
+            <section className='tabuada-description'>
+                <h2>🧠 Pitágoras e a popularização da tabuada</h2>
+                <p>
+                    O formato mais conhecido hoje surgiu na Grécia Antiga com a chamada <strong>Tabuada de Pitágoras</strong>. A
+                    matriz com linhas e colunas ajudava os alunos a identificar padrões e compreender propriedades da multiplicação.
+                </p>
+                <p>
+                    Além de memorizar resultados, a tabela estimulava a percepção de simetrias e reforçava a lógica por trás das
+                    operações. Esse método acabou influenciando gerações de educadores em todo o mundo.
+                </p>
+            </section>
+
+            <section className='tabuada-description'>
+                <h2>📚 Da Idade Média às escolas modernas</h2>
+                <p>
+                    Durante a Idade Média, a tabuada era ensinada em escolas monásticas como parte da formação básica em cálculo.
+                    Já no século XIX, com a expansão das escolas públicas, tornou-se um dos conteúdos obrigatórios para crianças.
+                </p>
+                <p>
+                    Professores utilizavam livros, cantigas e competições para tornar a memorização mais envolvente — estratégias
+                    que continuam eficazes e inspiram recursos educacionais até hoje.
+                </p>
+            </section>
+
+            <section className='tabuada-description'>
+                <h2>💡 A tabuada no século XXI</h2>
+                <p>
+                    Mesmo com calculadoras e dispositivos digitais, dominar a tabuada continua importante. Saber os resultados de
+                    cabeça facilita a resolução de problemas complexos, fortalece o raciocínio lógico e amplia a confiança dos
+                    estudantes nas aulas de matemática.
+                </p>
+                <p>
+                    Recursos online, como jogos, quizzes e desafios, permitem que cada pessoa aprenda no próprio ritmo. Aqui na
+                    <strong>Tabuada Divertida</strong>, reunimos essas ferramentas para transformar estudo em diversão.
+                </p>
+            </section>
+
+            <footer className='tabuada-description'>
+                <h2>🚀 Continue praticando</h2>
+                <p>
+                    Quer colocar todo esse conhecimento em prática? Explore a tabuada interativa disponível em nosso site e
+                    acompanhe sua evolução com desafios personalizados.
+                </p>
+                <Link className='global-button' to='/artigos/tabuada'>
+                    <span className='option-link'>
+                        Acesse a tabuada completa
+                    </span>
+                </Link>
+            </footer>
+        </div>
+    );
+}
+
+export default HistoriaTabuada;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -31,7 +31,7 @@ function Home() {
                     </div>
                 </section>
                 <section className='home-description'>
-                    <h1>Matemática divertida para todas as idades</h1>
+                    <h1>🎯 Matemática divertida para todas as idades</h1>
                     <p>
                         Tabuada Divertida é uma plataforma educacional criada para ajudar estudantes de todas as idades a praticarem matemática de maneira leve e envolvente.
                         Exercícios de multiplicação, divisão, adição e subtração são apresentados em formato de jogo, incentivando o aprendizado contínuo com rankings, objetivos claros e acompanhamento de progresso.
@@ -42,7 +42,7 @@ function Home() {
                     </p>
                 </section>
                 <section className='home-article-preview'>
-                    <h2>Por que aprender matemática com jogos funciona?</h2>
+                    <h2>🧠 Por que aprender matemática com jogos funciona?</h2>
                     <p>
                         Aprender brincando transforma o estudo em um desafio prazeroso, mantém a motivação em alta e ajuda a consolidar o conhecimento por meio de repetições significativas.
                         No nosso artigo especial compartilhamos evidências, boas práticas e dicas para aproveitar atividades lúdicas em sala de aula ou em casa.
@@ -54,7 +54,7 @@ function Home() {
                     </Link>
                 </section>
                 <section className='home-article-preview'>
-                    <h2>O que você encontra por aqui</h2>
+                    <h2>🧩 O que você encontra por aqui</h2>
                     <ul>
                         <li>✔️ Jogos de matemática para diferentes níveis</li>
                         <li>✔️ Histórico para acompanhar o desempenho</li>
@@ -63,7 +63,7 @@ function Home() {
                     </ul>
                 </section>
                 <section className='home-article-preview'>
-                    <h2>Seguro para crianças</h2>
+                    <h2>🛡️ Seguro para crianças</h2>
                     <p>
                         O Tabuada Divertida foi desenvolvido com foco total em segurança e privacidade. Nenhuma informação sensível é coletada, e todas as atividades são acessíveis sem login obrigatório.
                     </p>
@@ -88,11 +88,18 @@ function Home() {
                     <p>
                         No <strong>Tabuada Divertida</strong>, nossa missão é resgatar esse conhecimento de forma moderna, usando jogos e desafios que tornam o aprendizado mais leve, envolvente e divertido. Afinal, aprender pode — e deve — ser uma experiência prazerosa!
                     </p>
-                    <Link className='global-button' to='/artigos/tabuada'>
-                        <span className='option-link'>
-                            Acesse a tabuada
-                        </span>
-                    </Link>
+                    <div>
+                        <Link className='global-button' to='/artigos/historia-da-tabuada'>
+                            <span className='option-link'>
+                                Leia a história completa
+                            </span>
+                        </Link>
+                        <Link className='global-button' to='/artigos/tabuada'>
+                            <span className='option-link'>
+                                Acesse a tabuada
+                            </span>
+                        </Link>
+                    </div>
                 </section>
             </div>
         </div>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,6 +16,7 @@ import Contribua from './pages/Contribua/Contribua';
 import Header from './components/Header/index';
 import AprenderMatematicaJogos from './pages/Artigos/AprenderMatematicaJogos';
 import TabuadaPage from './pages/Artigos/TabuadaPage';
+import HistoriaTabuada from './pages/Artigos/HistoriaTabuada';
 import Artigos from './pages/Artigos/Artigos';
 
 interface RoutesAppProps {
@@ -42,6 +43,7 @@ function RoutesApp({ theme, toggleTheme }: RoutesAppProps) {
                 <Route path='/contato' element={<Contato/>}/>
                 <Route path='/artigos' element={<Artigos/>}/>
                 <Route path='/artigos/aprender-matematica-com-jogos' element={<AprenderMatematicaJogos/>}/>
+                <Route path='/artigos/historia-da-tabuada' element={<HistoriaTabuada/>}/>
                 <Route path='/artigos/tabuada' element={<TabuadaPage/>}/>
                 <Route path='/contribua' element={<Contribua/>}/>
                 <Route path='*' element={<Erro/>}/>


### PR DESCRIPTION
## Summary
- add a dedicated História da Tabuada article page with sections covering the evolution of multiplication tables
- include the new article in the Artigos list and router map
- refresh the home page headings with emojis and add quick links to both the history article and tabuada resource

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68da93499ba4832c9e3705a0bb47b202