### PR TITLE
Replace Link components with anchors

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,5 @@
 import ThemeSwitcher from '../ThemeSwitcher/themeSwitcher';
 import './style.css';
-import { Link } from 'react-router-dom';
 
 interface HeaderProps {
     theme: 'light' | 'dark';
@@ -11,12 +10,12 @@ function Header({ theme, toggleTheme }: HeaderProps){
     return(
         <header className='conNav'>
             <div className='toolNav'>
-                <Link className='logo option-link' to='/'>Tabuada Divertida</Link>
+                <a className='logo option-link' href='/'>Tabuada Divertida</a>
                 <div className='opcoes-head'>
-                    <Link className='ranking option-link' to='/ranking'>🔝Ranking🔝</Link>
-                    <Link className='ranking option-link' to='/historico'>🔝Histórico🔝</Link>
-                    <Link className='ranking option-link' to='/artigos'>🧠Artigos🧠</Link>
-                    <Link className='ranking option-link' to='/artigos/tabuada'>📘Tabuada📘</Link>
+                    <a className='ranking option-link' href='/ranking'>🔝Ranking🔝</a>
+                    <a className='ranking option-link' href='/historico'>🔝Histórico🔝</a>
+                    <a className='ranking option-link' href='/artigos'>🧠Artigos🧠</a>
+                    <a className='ranking option-link' href='/artigos/tabuada'>📘Tabuada📘</a>
                     <ThemeSwitcher theme={theme} toggleTheme={toggleTheme} />
                 </div>
             </div>

--- a/src/pages/Artigos/AprenderMatematicaJogos.tsx
+++ b/src/pages/Artigos/AprenderMatematicaJogos.tsx
@@ -1,5 +1,4 @@
 import './Artigos.css';
-import { Link } from 'react-router-dom';
 
 function AprenderMatematicaJogos() {
     return (
@@ -46,8 +45,8 @@ function AprenderMatematicaJogos() {
 
                 <p>
                     Quer colocar essas dicas em prática agora mesmo?
-                    Experimente uma partida na <Link to='/'>página inicial</Link> ou acesse o <Link to='/formulario'>formulário de jogo</Link> para escolher o nível e a operação que deseja treinar.
-                    Você também pode acompanhar a evolução no <Link to='/ranking'>ranking da comunidade</Link> e comparar seus resultados com as tentativas anteriores.
+                    Experimente uma partida na <a href='/'>página inicial</a> ou acesse o <a href='/formulario'>formulário de jogo</a> para escolher o nível e a operação que deseja treinar.
+                    Você também pode acompanhar a evolução no <a href='/ranking'>ranking da comunidade</a> e comparar seus resultados com as tentativas anteriores.
                 </p>
             </article>
         </main>

--- a/src/pages/Artigos/Artigos.tsx
+++ b/src/pages/Artigos/Artigos.tsx
@@ -1,5 +1,4 @@
 import './Artigos.css';
-import {Link} from 'react-router-dom';
 
 function Artigos(){
 
@@ -7,26 +6,26 @@ function Artigos(){
         <div className='center'>
             <div className='global-pageContainer-left options-preview'>
                 <div className='botoes'>
-                    <Link to={`/artigos/aprender-matematica-com-jogos`} className='global-button global-button--full-width'>
+                    <a href={`/artigos/aprender-matematica-com-jogos`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             Aprenda Matemática com jogos
                         </span>
-                    </Link>
-                    <Link to={`/artigos/historia-da-tabuada`} className='global-button global-button--full-width'>
+                    </a>
+                    <a href={`/artigos/historia-da-tabuada`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             História da Tabuada
                         </span>
-                    </Link>
-                    <Link to={`/artigos/tabuada`} className='global-button global-button--full-width'>
+                    </a>
+                    <a href={`/artigos/tabuada`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             Tabuada de Multiplicação e Divisão
                         </span>
-                    </Link>
-                    <Link to={`/artigos/beneficios-jogos-educacionas`} className='global-button global-button--full-width'>
+                    </a>
+                    <a href={`/artigos/beneficios-jogos-educacionas`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             Benefício dos Jogos Educacionais
                         </span>
-                    </Link>
+                    </a>
                 </div>
             </div>
         </div>

--- a/src/pages/Artigos/BeneficiosJogosEducacionais.tsx
+++ b/src/pages/Artigos/BeneficiosJogosEducacionais.tsx
@@ -1,5 +1,4 @@
 import './Artigos.css';
-import { Link } from 'react-router-dom';
 
 function BeneficiosJogosEducacionais() {
     return (
@@ -55,10 +54,10 @@ function BeneficiosJogosEducacionais() {
                 </ul>
 
                 <p>
-                    Na <strong>Tabuada Divertida</strong>, acreditamos que aprender pode ser tão divertido quanto jogar. 
-                    Experimente uma partida na <Link to='/'>página inicial</Link> ou explore o <Link to='/formulario'>formulário de jogo</Link> 
-                    para escolher o nível e a operação matemática que deseja treinar. 
-                    Você também pode comparar sua evolução no <Link to='/ranking'>ranking da comunidade</Link> e celebrar cada conquista!
+                    Na <strong>Tabuada Divertida</strong>, acreditamos que aprender pode ser tão divertido quanto jogar.
+                    Experimente uma partida na <a href='/'>página inicial</a> ou explore o <a href='/formulario'>formulário de jogo</a>
+                    para escolher o nível e a operação matemática que deseja treinar.
+                    Você também pode comparar sua evolução no <a href='/ranking'>ranking da comunidade</a> e celebrar cada conquista!
                 </p>
             </article>
         </main>

--- a/src/pages/Artigos/HistoriaTabuada.tsx
+++ b/src/pages/Artigos/HistoriaTabuada.tsx
@@ -1,5 +1,4 @@
 import './Artigos.css';
-import { Link } from 'react-router-dom';
 
 function HistoriaTabuada() {
     return (
@@ -70,11 +69,11 @@ function HistoriaTabuada() {
                     Quer colocar todo esse conhecimento em prática? Explore a tabuada interativa disponível em nosso site e
                     acompanhe sua evolução com desafios personalizados.
                 </p>
-                <Link className='global-button' to='/artigos/tabuada'>
+                <a className='global-button' href='/artigos/tabuada'>
                     <span className='option-link'>
                         Acesse a tabuada completa
                     </span>
-                </Link>
+                </a>
             </section>
         </div>
     );

--- a/src/pages/Erro/Erro.tsx
+++ b/src/pages/Erro/Erro.tsx
@@ -1,11 +1,9 @@
-import {Link} from 'react-router-dom';
-
 function Erro(){
     return(
         <div className="global-pageContainer-left">
             <h1>404</h1>
             <h2>Página não encontrada</h2>
-            <Link to="/">Home</Link>
+            <a href="/">Home</a>
         </div>
     )
 }

--- a/src/pages/Final/Final.tsx
+++ b/src/pages/Final/Final.tsx
@@ -1,4 +1,3 @@
-import {Link} from 'react-router-dom';
 import configData from "../../Config.json";
 import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
@@ -117,26 +116,26 @@ function Final(){
             </div>
 
             <div className='botoes'>
-                <Link className='global-button global-button--full-width' to={`/contagem/` + tipo}>
+                <a className='global-button global-button--full-width' href={`/contagem/` + tipo}>
                     <span className='option-link'>
                         Jogar novamente
                     </span>
-                </Link>
-                <Link className='global-button global-button--full-width' to={`/ranking`}>
+                </a>
+                <a className='global-button global-button--full-width' href={`/ranking`}>
                     <span className='option-link'>
-                        Ranking 
+                        Ranking
                     </span>
-                </Link>
-                <Link className='global-button global-button--full-width' to="/historico">
+                </a>
+                <a className='global-button global-button--full-width' href="/historico">
                     <span className='option-link'>
                         Histórico
                     </span>
-                </Link>
-                <Link className='global-button global-button--full-width' to="/">
+                </a>
+                <a className='global-button global-button--full-width' href="/">
                     <span className='option-link'>
                         Início
                     </span>
-                </Link>
+                </a>
             </div>
         </div>
     )

--- a/src/pages/Historico/Historico.tsx
+++ b/src/pages/Historico/Historico.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import configData from "../../Config.json";
 import { Table } from 'react-bootstrap';
-import {Link} from 'react-router-dom';
 
 function Historico(){
     const [historico, setHistorico] = useState(new Array());
@@ -145,11 +144,11 @@ function Historico(){
                     </tbody>
                 </table>
                 <div className='botoes'>
-                    <Link className='global-button global-button--full-width global-button--back' to="/">
+                    <a className='global-button global-button--full-width global-button--back' href="/">
                         <span className='option-link'>
                             Voltar
                         </span>
-                    </Link>
+                    </a>
                 </div>
             </div>
         </div>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import HappyRobot from '../../components/HappyRobot/HappyRobot';
 
 function Home() {
@@ -8,31 +7,31 @@ function Home() {
                 <section className='options-preview'>
                     <HappyRobot />
                     <div className='botoes-home'>
-                        <Link className='global-button global-button--full-width' to={`/formulario`}>
+                        <a className='global-button global-button--full-width' href={`/formulario`}>
                             <span className='option-link'>
                                 🎮 Jogar Agora
                             </span>
-                        </Link>
-                        <Link className='global-button global-button--full-width' to={`/instrucoes`}>
+                        </a>
+                        <a className='global-button global-button--full-width' href={`/instrucoes`}>
                             <span className='option-link'>
                                 🤔 Como Jogar?
                             </span>
-                        </Link>
-                        <Link className='global-button global-button--full-width' to={`/ranking`}>
+                        </a>
+                        <a className='global-button global-button--full-width' href={`/ranking`}>
                             <span className='option-link'>
                                 🏆 Ranking
                             </span>
-                        </Link>
-                        <Link className='global-button global-button--full-width' to={`/historico`}>
+                        </a>
+                        <a className='global-button global-button--full-width' href={`/historico`}>
                             <span className='option-link'>
                                 📝 Minhas Partidas
                             </span>
-                        </Link>
-                        <Link className='global-button global-button--full-width' to={`/artigos`}>
+                        </a>
+                        <a className='global-button global-button--full-width' href={`/artigos`}>
                             <span className='option-link'>
                                 🧠 Artigos
                             </span>
-                        </Link>
+                        </a>
                     </div>
                 </section>
                 <section className='home-description'>
@@ -52,11 +51,11 @@ function Home() {
                         Aprender brincando transforma o estudo em um desafio prazeroso, mantém a motivação em alta e ajuda a consolidar o conhecimento por meio de repetições significativas.
                         No nosso artigo especial compartilhamos evidências, boas práticas e dicas para aproveitar atividades lúdicas em sala de aula ou em casa.
                     </p>
-                    <Link className='global-button' to='/artigos/aprender-matematica-com-jogos'>
+                    <a className='global-button' href='/artigos/aprender-matematica-com-jogos'>
                         <span className='option-link'>
                             Leia o artigo completo
                         </span>
-                    </Link>
+                    </a>
                 </section>
                 <section className='home-article-preview'>
                     <h2>🧩 O que você encontra por aqui</h2>
@@ -94,16 +93,16 @@ function Home() {
                         No <strong>Tabuada Divertida</strong>, nossa missão é resgatar esse conhecimento de forma moderna, usando jogos e desafios que tornam o aprendizado mais leve, envolvente e divertido. Afinal, aprender pode — e deve — ser uma experiência prazerosa!
                     </p>
                     <div className='gap-default'>
-                        <Link className='global-button' to='/artigos/historia-da-tabuada'>
+                        <a className='global-button' href='/artigos/historia-da-tabuada'>
                             <span className='option-link'>
                                 Leia a história completa
                             </span>
-                        </Link>
-                        <Link className='global-button' to='/artigos/tabuada'>
+                        </a>
+                        <a className='global-button' href='/artigos/tabuada'>
                             <span className='option-link'>
                                 Acesse a tabuada
                             </span>
-                        </Link>
+                        </a>
                     </div>
                 </section>
             </div>

--- a/src/pages/Instrucoes/Instrucoes.tsx
+++ b/src/pages/Instrucoes/Instrucoes.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import {Link} from 'react-router-dom';
 import happyRobot from '../../assets/robot-happy.svg';
 
 function Instrucoes(){
@@ -56,11 +55,11 @@ function Instrucoes(){
 
         Vamos lá, mostre suas habilidades e deixe todos boquiabertos com seu conhecimento matemágico! 💥 <br/><br/>   
         </h3>    
-        <Link className='global-button global-button--full-width global-button--back' to="/">
+        <a className='global-button global-button--full-width global-button--back' href="/">
             <span className='option-link'>
                 Voltar
             </span>
-        </Link>
+        </a>
     </div>
     )
 }

--- a/src/pages/Jogo/Jogo.tsx
+++ b/src/pages/Jogo/Jogo.tsx
@@ -1,7 +1,6 @@
 import configData from "../../Config.json";
 import Tempo from '../../components/Tempo';
 import api from '../../services/api';
-import {Link} from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {toast} from 'react-toastify';
@@ -251,7 +250,7 @@ function Jogo(){
             <div className='container'>
                 <div className='not-found'>
                     Não existe essa opção.
-                    <Link to="/">Home</Link>
+                    <a href="/">Home</a>
                 </div>
             </div>
         )

--- a/src/pages/Ranking/Ranking.tsx
+++ b/src/pages/Ranking/Ranking.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {Link} from 'react-router-dom';
 import api from '../../services/api';
 import { Table } from 'react-bootstrap';
 import Config from '../../Config.json';
@@ -189,8 +188,8 @@ function Ranking(){
                 </div>
             </div>
             <div className='botoes'>
-                <Link className='global-button global-button--full-width' to="/historico">Histórico</Link>
-                <Link className='global-button global-button--full-width global-button--back' to="/">Voltar</Link>
+                <a className='global-button global-button--full-width' href="/historico">Histórico</a>
+                <a className='global-button global-button--full-width global-button--back' href="/">Voltar</a>
             </div>
         </div>
     )

--- a/src/pages/TipoJogo/TipoJogo.tsx
+++ b/src/pages/TipoJogo/TipoJogo.tsx
@@ -1,5 +1,3 @@
-import {Link} from 'react-router-dom';
-
 function TipoJogo(){
 
     return(
@@ -7,36 +5,36 @@ function TipoJogo(){
             <div className='global-pageContainer-left options-preview'>
                 <div className='botoes'>
                     <h3> Selecione a operação matemática que deseja jogar ➕ ➖ ✖️ ➗ 🔢</h3>
-                    <Link to={`/contagem/M`} className='global-button global-button--full-width'>
+                    <a href={`/contagem/M`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             Multiplicação✖️
                         </span>
-                    </Link>
-                    <Link to={`/contagem/A`} className='global-button global-button--full-width'>
+                    </a>
+                    <a href={`/contagem/A`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             Adição➕
                         </span>
-                    </Link>
-                    <Link to={`/contagem/S`} className='global-button global-button--full-width'>
+                    </a>
+                    <a href={`/contagem/S`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             Subtração➖
                         </span>
-                    </Link>
-                    <Link to={`/contagem/D`} className='global-button global-button--full-width'>
+                    </a>
+                    <a href={`/contagem/D`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             Divisão➗
                         </span>
-                    </Link>
-                    <Link to={`/contagem/R`} className='global-button global-button--full-width'>
+                    </a>
+                    <a href={`/contagem/R`} className='global-button global-button--full-width'>
                         <span className='option-link'>
                             Aleatório🔀
                         </span>
-                    </Link>
-                    <Link to={`/formulario`} className='global-button global-button--full-width global-button--back'>
+                    </a>
+                    <a href={`/formulario`} className='global-button global-button--full-width global-button--back'>
                         <span className='option-link'>
                             Voltar
                         </span>
-                    </Link>
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- replace `Link` components with plain anchor tags where navigation is static
- remove unused `Link` imports from the affected components and pages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd8d8ec1c0832c8a64104ac8adcbc3